### PR TITLE
Extend capabilities of Link component, add new recipes

### DIFF
--- a/docs/navBar.mdx
+++ b/docs/navBar.mdx
@@ -1,0 +1,34 @@
+---
+name: Navbar
+menu: Recipes
+---
+
+import { Playground, PropsTable } from 'docz';
+import { Box, Flex, Link, Text } from '../src';
+
+# Navbar
+
+Application specific component for displaying a site's primary navigation bar.
+
+<Playground>
+    <Flex as="header">
+        <Link
+            color="black"
+            fontSize={4}
+            mr="auto"
+            fontWeight="bold"
+            textDecoration="none"
+        >
+            Lyca
+        </Link>
+        <Flex as="nav" ml="auto" alignItems="center" justifyContent="flex-end">
+            <Link href="#">Get Started</Link>
+            <Link href="#" ml={2}>
+                Components
+            </Link>
+            <Link href="#" ml={2}>
+                Recipes
+            </Link>
+        </Flex>
+    </Flex>
+</Playground>

--- a/docs/profileCard.mdx
+++ b/docs/profileCard.mdx
@@ -1,22 +1,23 @@
 ---
 name: Profile Card
-menu: Components
+menu: Recipes
 ---
 
 import { Playground, PropsTable } from 'docz';
-import { ProfileCard } from '../src';
+import { Avatar, Card, Heading, Text } from '../src';
 
 # Profile Card
 
-Component for displaying user profiles.
-
-## Standard
+Application specific component for showing a user's avatar and profile information.
 
 <Playground>
-    <ProfileCard
-        image="http://tachyons.io/img/avatar_1.jpg"
-        alt="Image of a blepping cat"
-        name="Grizzly B."
-        title="CBO (Chief Barking Officer)"
-    />
+    <Card textAlign="center">
+        <Avatar
+            src="https://placedog.net/500/500"
+            alt="Sir Barksalot"
+            mx="auto"
+        />
+        <Heading my={1}>Sir Barksalot</Heading>
+        <Text my={0}>CBO (Chief Barking Officer)</Text>
+    </Card>
 </Playground>

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,5 +1,17 @@
 import styled from 'styled-components';
-import { color, themeGet } from 'styled-system';
+import {
+    color,
+    fontSize,
+    fontWeight,
+    space,
+    themeGet,
+    style,
+} from 'styled-system';
+
+const textDecoration = style({
+    prop: 'textDecoration',
+    cssProperty: 'textDecoration',
+});
 
 const Link = styled.a`
     cursor: pointer;
@@ -11,13 +23,21 @@ const Link = styled.a`
         text-decoration: none;
     }
 
-    ${color}
+	${color}
+	${fontSize}
+	${fontWeight}
+	${space}
+	${textDecoration}
 `;
 
 Link.displayName = 'Link';
 
 Link.propTypes = {
     ...color.propTypes,
+    ...fontSize.propTypes,
+    ...fontWeight.propTypes,
+    ...space.propTypes,
+    ...textDecoration.propTypes,
 };
 
 Link.defaultProps = {


### PR DESCRIPTION
#2 

Removes `ProfileCard` and moves it under the recipes section. Adds `NavBar` recipe and expands the API of the `Link` component.